### PR TITLE
Support block delete with alt and meta modifiers

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -990,16 +990,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       return ''; 
     } 
 
-    String result = text.trimRight();
-    final int characterBoundary = _getLeftByWord(_textPainter, text.length - 1, false);
-    result = result.substring(0, characterBoundary);
-    return result;
+    final String result = text.trimRight();
+    final int characterBoundary = _getLeftByWord(_textPainter, text.length, false);
+    return result.substring(0, characterBoundary);
   }
 
   /// Computes the text after a delete event
   String _computeBeforeTextWithBackspace({ required String text }) {
-    final int characterBoundary = previousCharacter(text.length, text);
-    return text.substring(0, characterBoundary);
+    return text.substring(0, previousCharacter(text.length, text));
   }
 
   void _handleDelete({ 

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -979,7 +979,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
   }
 
-  /// Computes the text after a delete event with a alt or meta modifier
+  /// Computes the text after a delete event with a alt or meta modifier.
   String _computeDeletedBeforeTextWithModifier({
     required String text,
     bool isWordModifierPressed = false,
@@ -999,7 +999,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return result.substring(0, characterBoundary);
   }
 
-  /// Computes the text after a delete event
+  /// Computes the text after a delete event.
   String _computeDeletedBeforeText({ required String text }) {
     return text.substring(0, previousCharacter(text.length, text));
   }

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -980,7 +980,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   /// Computes the text after a delete event with a alt or meta modifier
-  String _computeBeforeTextWithBlockBackspace({ 
+  String _computeDeletedBeforeTextWithModifier({ 
     required String text, 
     bool isWordModifierPressed = false, 
     bool isLineModifierPressed = false 
@@ -1000,7 +1000,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   /// Computes the text after a delete event
-  String _computeBeforeTextWithBackspace({ required String text }) {
+  String _computeDeletedBeforeText({ required String text }) {
     return text.substring(0, previousCharacter(text.length, text));
   }
 
@@ -1026,9 +1026,9 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
         final bool hasModifier = isWordModifierPressed || isLineModifierPressed;
         
         if (!hasModifier || endsWithBreakLine) {
-          textBefore = _computeBeforeTextWithBackspace(text: textBefore);
+          textBefore = _computeDeletedBeforeText(text: textBefore);
         } else {
-          textBefore = _computeBeforeTextWithBlockBackspace(
+          textBefore = _computeDeletedBeforeTextWithModifier(
             text: textBefore, 
             isWordModifierPressed: isWordModifierPressed, 
             isLineModifierPressed: isLineModifierPressed

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -637,7 +637,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     final Set<LogicalKeyboardKey> keysPressed = LogicalKeyboardKey.collapseSynonyms(RawKeyboard.instance.keysPressed);
     final LogicalKeyboardKey key = keyEvent.logicalKey;
 
-    final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
+    final bool isMacOS = keyEvent.data is RawKeyEventDataMacOs;
     if (!_nonModifierKeys.contains(key) ||
         keysPressed.difference(isMacOS ? _macOsModifierKeys : _modifierKeys).length > 1 ||
         keysPressed.difference(_interestingKeys).isNotEmpty) {
@@ -660,15 +660,15 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
       _handleDelete(forward: true);
     } else if (key == LogicalKeyboardKey.backspace) {
       _handleDelete(
-        forward: false, 
-        isWordModifierPressed: isWordModifierPressed, 
+        forward: false,
+        isWordModifierPressed: isWordModifierPressed,
         isLineModifierPressed: isLineModifierPressed
       );
     } else if (isShortcutModifierPressed && _shortcutKeys.contains(key)) {
       // _handleShortcuts depends on being started in the same stack invocation
       // as the _handleKeyEvent method
       _handleShortcuts(key);
-    } 
+    }
   }
 
   // Return the offset at the start of the nearest word to the left of the given
@@ -980,10 +980,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   /// Computes the text after a delete event with a alt or meta modifier
-  String _computeDeletedBeforeTextWithModifier({ 
-    required String text, 
-    bool isWordModifierPressed = false, 
-    bool isLineModifierPressed = false 
+  String _computeDeletedBeforeTextWithModifier({
+    required String text,
+    bool isWordModifierPressed = false,
+    bool isLineModifierPressed = false
   }) {
     // if both modifiers are true, then we should ignore.
     if (isLineModifierPressed && isWordModifierPressed) {
@@ -991,8 +991,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     }
 
     if (isLineModifierPressed) {
-      return ''; 
-    } 
+      return '';
+    }
 
     final String result = text.trimRight();
     final int characterBoundary = _getLeftByWord(_textPainter, text.length, false);
@@ -1004,8 +1004,8 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     return text.substring(0, previousCharacter(text.length, text));
   }
 
-  void _handleDelete({ 
-    required bool forward, 
+  void _handleDelete({
+    required bool forward,
     bool isWordModifierPressed = false,
     bool isLineModifierPressed = false
   }) {
@@ -1018,19 +1018,19 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
     String textBefore = selection.textBefore(text);
     String textAfter = selection.textAfter(text);
     int cursorPosition = math.min(selection.start, selection.end);
-    
+
     // If not deleting a selection, delete the next/previous character.
     if (selection.isCollapsed) {
       if (!forward && textBefore.isNotEmpty) {
         final bool endsWithBreakLine = textBefore.codeUnitAt(textBefore.length - 1) == 0x0A;
         final bool hasModifier = isWordModifierPressed || isLineModifierPressed;
-        
+
         if (!hasModifier || endsWithBreakLine) {
           textBefore = _computeDeletedBeforeText(text: textBefore);
         } else {
           textBefore = _computeDeletedBeforeTextWithModifier(
-            text: textBefore, 
-            isWordModifierPressed: isWordModifierPressed, 
+            text: textBefore,
+            isWordModifierPressed: isWordModifierPressed,
             isLineModifierPressed: isLineModifierPressed
           );
         }

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1562,383 +1562,487 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
   
-    test('handles blocks deletion with meta modifier when cursor is on last position', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = text.length;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+    group('when using macOS', () {
+      setUp(() {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      });
+
+      tearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+      });
+      
+      test('handles blocks deletion with meta modifier when cursor is on last position', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = text.length;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
 
-      expect(delegate.textEditingValue.text, '');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, '');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 0);
+      }, skip: isBrowser);
 
-    test('handles blocks deletion with meta modifier when cursor is on the middle of a block', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 8;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles blocks deletion with meta modifier when cursor is on the middle of a block', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = 8;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
 
-      expect(delegate.textEditingValue.text, 'h multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 0);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'h multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 0);
+      }, skip: isBrowser);
 
-    test('handles block deletion with meta modifier when cursor is preceeded by break line', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with meta modifier when cursor is preceeded by break line', () async {
+        const String text = 'test with\n\n\nmultiple blocks';
+        const int offset = 12;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
 
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 11);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 11);
+      }, skip: isBrowser);
 
-    test('handles block deletion with alt modifier when cursor is on the middle of a block', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 8;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with alt modifier when cursor is on the middle of a block', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = 8;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
 
-      expect(delegate.textEditingValue.text, 'test h multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'test h multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 5);
+      }, skip: isBrowser);
 
-    test('handles block deletion with alt modifier when cursor is after a block', () async {
-      const String text = 'test with multiple blocks';
-      const int offset = 9;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with alt modifier when cursor is after a block', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = 9;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
 
-      expect(delegate.textEditingValue.text, 'test  multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'test  multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 5);
+      }, skip: isBrowser);
 
-    test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
-      const String text = 'test with   multiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
+        const String text = 'test with   multiple blocks';
+        const int offset = 12;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
 
-      expect(delegate.textEditingValue.text, 'test multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'test multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 5);
+      }, skip: isBrowser);
 
-    test('handles block deletion with alt modifier when cursor is preceeded by tabs spaces', () async {
-      const String text = 'test with\t\t\tmultiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with alt modifier when cursor is preceeded by tabs spaces', () async {
+        const String text = 'test with\t\t\tmultiple blocks';
+        const int offset = 12;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
 
-      expect(delegate.textEditingValue.text, 'test multiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 5);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, 'test multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 5);
+      }, skip: isBrowser);
+      
+      test('handles block deletion with alt modifier when cursor is preceeded by break line', () async {
+        const String text = 'test with\n\n\nmultiple blocks';
+        const int offset = 12;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+        expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 11);
+      }, skip: isBrowser);
     
-    test('handles block deletion with alt modifier when cursor is preceeded by break line', () async {
-      const String text = 'test with\n\n\nmultiple blocks';
-      const int offset = 12;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+      test('handles block deletion with alt modifier when using cjk chinese', () async {
+        const String text = '用多個塊測試';
+        const int offset = 4;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
 
-      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 11);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, '用多個測試');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 3);
+      }, skip: isBrowser);
+    });
   
-    test('handles block deletion with alt modifier when using cjk chinese', () async {
-      const String text = '用多個塊測試';
-      const int offset = 4;
-      final TextSelectionDelegate delegate = FakeEditableTextState()
-        ..textEditingValue = const TextEditingValue(
+    group('when not using macOS', () {
+      setUp(() {
+        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      });
+
+      tearDown(() {
+        debugDefaultTargetPlatformOverride = null;
+      });
+      
+      test('ignores blocks deletion with meta modifier', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = text.length;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
             text: text,
-            selection: TextSelection.collapsed(offset: offset),
-          );
-      final ViewportOffset viewportOffset = ViewportOffset.zero();
-      final RenderEditable editable = RenderEditable(
-        backgroundCursorColor: Colors.grey,
-        selectionColor: Colors.black,
-        textDirection: TextDirection.ltr,
-        cursorColor: Colors.red,
-        offset: viewportOffset,
-        textSelectionDelegate: delegate,
-        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        text: const TextSpan(
-          text: text,
-          style: TextStyle(
-            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
           ),
-        ),
-        selection: const TextSelection.collapsed(offset: offset),
-      );
+          selection: const TextSelection.collapsed(offset: offset),
+        );
 
-      layout(editable);
-      editable.hasFocus = true;
-      pumpFrame();
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
 
-      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.meta);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.meta);
 
-      expect(delegate.textEditingValue.text, '用多個測試');
-      expect(delegate.textEditingValue.selection.isCollapsed, true);
-      expect(delegate.textEditingValue.selection.baseOffset, 3);
-    }, skip: isBrowser);
+        expect(delegate.textEditingValue.text, text);
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, offset);
+      }, skip: isBrowser);
+
+      test('handles block deletion with ctrl modifier', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = 8;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        await simulateKeyDownEvent(LogicalKeyboardKey.control);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.control);
+
+        expect(delegate.textEditingValue.text, 'test h multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 5);
+      }, skip: isBrowser);
+    });
   });
 
   test('getEndpointsForSelection handles empty characters', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1562,7 +1562,7 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
   
-    group('when using macOS', () {
+    group('with modifier keys on macOS', () {
       setUp(() {
         debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       });
@@ -1950,7 +1950,7 @@ void main() {
       }, skip: isBrowser);
     });
   
-    group('when not using macOS', () {
+    group('with modifier keys and not using macOS', () {
       setUp(() {
         debugDefaultTargetPlatformOverride = TargetPlatform.windows;
       });
@@ -1999,6 +1999,48 @@ void main() {
         expect(delegate.textEditingValue.text, text);
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, offset);
+      }, skip: isBrowser);
+
+      test('handles block deletion with alt modifier', () async {
+        const String text = 'test with multiple blocks';
+        const int offset = 8;
+        final TextSelectionDelegate delegate = FakeEditableTextState()
+          ..textEditingValue = const TextEditingValue(
+              text: text,
+              selection: TextSelection.collapsed(offset: offset),
+            );
+        final ViewportOffset viewportOffset = ViewportOffset.zero();
+        final RenderEditable editable = RenderEditable(
+          backgroundCursorColor: Colors.grey,
+          selectionColor: Colors.black,
+          textDirection: TextDirection.ltr,
+          cursorColor: Colors.red,
+          offset: viewportOffset,
+          textSelectionDelegate: delegate,
+          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+          startHandleLayerLink: LayerLink(),
+          endHandleLayerLink: LayerLink(),
+          text: const TextSpan(
+            text: text,
+            style: TextStyle(
+              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+            ),
+          ),
+          selection: const TextSelection.collapsed(offset: offset),
+        );
+
+        layout(editable);
+        editable.hasFocus = true;
+        pumpFrame();
+
+        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyUpEvent(LogicalKeyboardKey.control);
+
+        expect(delegate.textEditingValue.text, 'h multiple blocks');
+        expect(delegate.textEditingValue.selection.isCollapsed, true);
+        expect(delegate.textEditingValue.selection.baseOffset, 0);
       }, skip: isBrowser);
 
       test('handles block deletion with ctrl modifier', () async {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1561,6 +1561,300 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
+  
+    test('handles blocks deletion with meta modifier when cursor is on last position', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+
+      expect(delegate.textEditingValue.text, '');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('handles blocks deletion with meta modifier when cursor is on the middle of a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+
+      expect(delegate.textEditingValue.text, 'h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
+
+    test('handles block deletion with meta modifier when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.meta);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.meta);
+
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+
+    test('handles block deletion with alt modifier when cursor is on the middle of a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, 'test h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('handles block deletion with alt modifier when cursor is preceeded by tabs spaces', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+    
+    test('handles block deletion with alt modifier when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
   });
 
   test('getEndpointsForSelection handles empty characters', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1730,6 +1730,48 @@ void main() {
       expect(delegate.textEditingValue.selection.baseOffset, 5);
     }, skip: isBrowser);
 
+    test('handles block deletion with alt modifier when cursor is after a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, 'test  multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
     test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
       const String text = 'test with   multiple blocks';
       const int offset = 12;
@@ -1854,6 +1896,48 @@ void main() {
       expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+  
+    test('handles block deletion with alt modifier when using cjk chinese', () async {
+      const String text = '用多個塊測試';
+      const int offset = 4;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
+            text: text,
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
+          ),
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
+
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
+
+      await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+
+      expect(delegate.textEditingValue.text, '用多個測試');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
   });
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1561,353 +1561,352 @@ void main() {
       expect(delegate.textEditingValue.selection.isCollapsed, true);
       expect(delegate.textEditingValue.selection.baseOffset, 3);
     }, skip: isBrowser);
-  
-    group('with modifier keys on macOS', () {
-      setUp(() {
-        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-      });
 
-      tearDown(() {
-        debugDefaultTargetPlatformOverride = null;
-      });
-      
-      test('handles blocks deletion with meta modifier when cursor is on last position', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = text.length;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles blocks deletion with line modifier when cursor is on last position', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = text.length;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.alt;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, '');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 0);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, '');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
 
-      test('handles blocks deletion with meta modifier when cursor is on the middle of a block', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = 8;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles blocks deletion with line modifier when cursor is on the middle of a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.alt;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'h multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 0);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, 'h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 0);
+    }, skip: isBrowser);
 
-      test('handles block deletion with meta modifier when cursor is preceeded by break line', () async {
-        const String text = 'test with\n\n\nmultiple blocks';
-        const int offset = 12;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles block deletion with line modifier when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.meta, platform: 'macos');
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.meta, platform: 'macos');
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.alt;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 11);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
 
-      test('handles block deletion with alt modifier when cursor is on the middle of a block', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = 8;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles block deletion with alt modifier when cursor is on the middle of a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 8;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test h multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 5);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, 'test h multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
 
-      test('handles block deletion with alt modifier when cursor is after a block', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = 9;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles block deletion with alt modifier when cursor is after a block', () async {
+      const String text = 'test with multiple blocks';
+      const int offset = 9;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test  multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 5);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, 'test  multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
 
-      test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
-        const String text = 'test with   multiple blocks';
-        const int offset = 12;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles block deletion with alt modifier when cursor is preceeded by white spaces', () async {
+      const String text = 'test with   multiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 5);
-      }, skip: isBrowser);
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
 
-      test('handles block deletion with alt modifier when cursor is preceeded by tabs spaces', () async {
-        const String text = 'test with\t\t\tmultiple blocks';
-        const int offset = 12;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+    test('handles block deletion with alt modifier when cursor is preceeded by tabs spaces', () async {
+      const String text = 'test with\t\t\tmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 5);
-      }, skip: isBrowser);
-      
-      test('handles block deletion with alt modifier when cursor is preceeded by break line', () async {
-        const String text = 'test with\n\n\nmultiple blocks';
-        const int offset = 12;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
+      expect(delegate.textEditingValue.text, 'test multiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 5);
+    }, skip: isBrowser);
+
+    test('handles block deletion with alt modifier when cursor is preceeded by break line', () async {
+      const String text = 'test with\n\n\nmultiple blocks';
+      const int offset = 12;
+      final TextSelectionDelegate delegate = FakeEditableTextState()
+        ..textEditingValue = const TextEditingValue(
             text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
+            selection: TextSelection.collapsed(offset: offset),
+          );
+      final ViewportOffset viewportOffset = ViewportOffset.zero();
+      final RenderEditable editable = RenderEditable(
+        backgroundCursorColor: Colors.grey,
+        selectionColor: Colors.black,
+        textDirection: TextDirection.ltr,
+        cursorColor: Colors.red,
+        offset: viewportOffset,
+        textSelectionDelegate: delegate,
+        onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
+        startHandleLayerLink: LayerLink(),
+        endHandleLayerLink: LayerLink(),
+        text: const TextSpan(
+          text: text,
+          style: TextStyle(
+            height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
           ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
+        ),
+        selection: const TextSelection.collapsed(offset: offset),
+      );
 
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
+      layout(editable);
+      editable.hasFocus = true;
+      pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+      final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+      await simulateKeyDownEvent(modifier);
+      await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
+      await simulateKeyUpEvent(modifier);
 
-        expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 11);
-      }, skip: isBrowser);
-    
-      test('handles block deletion with alt modifier when using cjk chinese', () async {
+      expect(delegate.textEditingValue.text, 'test with\n\nmultiple blocks');
+      expect(delegate.textEditingValue.selection.isCollapsed, true);
+      expect(delegate.textEditingValue.selection.baseOffset, 11);
+    }, skip: isBrowser);
+
+    test('handles block deletion with alt modifier when using cjk chinese', () async {
         const String text = '用多個塊測試';
         const int offset = 4;
         final TextSelectionDelegate delegate = FakeEditableTextState()
@@ -1939,152 +1938,16 @@ void main() {
         editable.hasFocus = true;
         pumpFrame();
 
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
+        final LogicalKeyboardKey modifier = Platform.isMacOS ? LogicalKeyboardKey.alt : LogicalKeyboardKey.control;
+        await simulateKeyDownEvent(modifier);
         await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
         await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
+        await simulateKeyUpEvent(modifier);
 
         expect(delegate.textEditingValue.text, '用多個測試');
         expect(delegate.textEditingValue.selection.isCollapsed, true);
         expect(delegate.textEditingValue.selection.baseOffset, 3);
       }, skip: isBrowser);
-    });
-  
-    group('with modifier keys and not using macOS', () {
-      setUp(() {
-        debugDefaultTargetPlatformOverride = TargetPlatform.windows;
-      });
-
-      tearDown(() {
-        debugDefaultTargetPlatformOverride = null;
-      });
-      
-      test('ignores blocks deletion with meta modifier', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = text.length;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        await simulateKeyDownEvent(LogicalKeyboardKey.meta);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.meta);
-
-        expect(delegate.textEditingValue.text, text);
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, offset);
-      }, skip: isBrowser);
-
-      test('handles block deletion with alt modifier', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = 8;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        await simulateKeyDownEvent(LogicalKeyboardKey.alt);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.alt);
-        await simulateKeyUpEvent(LogicalKeyboardKey.control);
-
-        expect(delegate.textEditingValue.text, 'h multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 0);
-      }, skip: isBrowser);
-
-      test('handles block deletion with ctrl modifier', () async {
-        const String text = 'test with multiple blocks';
-        const int offset = 8;
-        final TextSelectionDelegate delegate = FakeEditableTextState()
-          ..textEditingValue = const TextEditingValue(
-              text: text,
-              selection: TextSelection.collapsed(offset: offset),
-            );
-        final ViewportOffset viewportOffset = ViewportOffset.zero();
-        final RenderEditable editable = RenderEditable(
-          backgroundCursorColor: Colors.grey,
-          selectionColor: Colors.black,
-          textDirection: TextDirection.ltr,
-          cursorColor: Colors.red,
-          offset: viewportOffset,
-          textSelectionDelegate: delegate,
-          onSelectionChanged: (TextSelection selection, RenderEditable renderObject, SelectionChangedCause cause) {},
-          startHandleLayerLink: LayerLink(),
-          endHandleLayerLink: LayerLink(),
-          text: const TextSpan(
-            text: text,
-            style: TextStyle(
-              height: 1.0, fontSize: 10.0, fontFamily: 'Ahem',
-            ),
-          ),
-          selection: const TextSelection.collapsed(offset: offset),
-        );
-
-        layout(editable);
-        editable.hasFocus = true;
-        pumpFrame();
-
-        await simulateKeyDownEvent(LogicalKeyboardKey.control);
-        await simulateKeyDownEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.backspace);
-        await simulateKeyUpEvent(LogicalKeyboardKey.control);
-
-        expect(delegate.textEditingValue.text, 'test h multiple blocks');
-        expect(delegate.textEditingValue.selection.isCollapsed, true);
-        expect(delegate.textEditingValue.selection.baseOffset, 5);
-      }, skip: isBrowser);
-    });
   });
 
   test('getEndpointsForSelection handles empty characters', () {


### PR DESCRIPTION
This PR focuses on supporting modifiers to delete blocks of text in a editable widget.

### Shortcuts per OS
* macOS
  * **CMD (⌘) + Backspace**: Delete all words left to the cursor
  * **Option + Backspace**: Delete word left to the cursor
* Non macOS
  * **Alt + Backspace**: Delete all words left to the cursor
  * **Ctrl + Backspace**: Delete word left to the cursor

### Remarkable edge cases:
* when the cursor is preceded by a break line, independently of modifiers only the last character is deleted
* when using CJK characters the option/ctrl modifier only deletes a single character   

### Related issue: 
* https://github.com/flutter/flutter/issues/57015

### Future work:
If the approach used here is approved, I'll look into the same feature but for the "forward" delete, ie. `CMD + Delete`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
